### PR TITLE
Revert "Don't openssl on mac aarch64"

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -39,9 +39,7 @@ else
   fi
   export PATH="/Users/jenkins/ccache-3.2.4:$PATH"
   if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
-    if [ "${ARCHITECTURE}" == "x64" ]; then
-      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched --enable-openssl-bundling"
-    fi
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched --enable-openssl-bundling"
   else
     if [ "${ARCHITECTURE}" == "x64" ]; then
       # We can only target 10.9 on intel macs


### PR DESCRIPTION
This reverts commit 38260767786a9ae281958d16f37be7cb4e173178.

This is now supported. see ibmruntimes/openj9-openjdk-jdk18/14
Also related eclipse-openj9/openj9#14444