### PR TITLE
Enable gcc v11.2.0 on Linux platforms for Semeru 19+

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -191,6 +191,11 @@ elif [ "$JAVA_FEATURE_VERSION" -ge 17 ] && [ "${VARIANT}" != "${BUILD_VARIANT_OP
 elif [ "$JAVA_FEATURE_VERSION" -gt 17 ] && [ "${VARIANT}" != "${BUILD_VARIANT_OPENJ9}" ] && [ -r /usr/bin/gcc-10 ]; then
   [ -r /usr/bin/gcc-10 ] && export  CC=/usr/bin/gcc-10
   [ -r /usr/bin/g++-10 ] && export CXX=/usr/bin/g++-10
+elif [ "$JAVA_FEATURE_VERSION" -ge 19 ] && [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ] && [ -r /usr/local/gcc11/bin/gcc-11.2 ]; then
+  export PATH=/usr/local/gcc11/bin:$PATH
+  [ -r /usr/local/gcc11/bin/gcc-11.2 ] && export CC=/usr/local/gcc11/bin/gcc-11.2
+  [ -r /usr/local/gcc11/bin/g++-11.2 ] && export CXX=/usr/local/gcc11/bin/g++-11.2
+  export LD_LIBRARY_PATH=/usr/local/gcc11/lib64:/usr/local/gcc11/lib
 # Continue to use GCC 7 if present for JDK<=17 and where 10 does not exist
 elif [ -r /usr/local/gcc/bin/gcc-7.5 ]; then
   export PATH=/usr/local/gcc/bin:$PATH

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1652,7 +1652,8 @@ addJ9Tag() {
   # This code makes sure that a version number is always present in the release file i.e. openj9-0.21.0
   local j9Location="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/openj9"
   # Pull the tag associated with the J9 commit being used
-  J9_TAG=$(git -C $j9Location describe --abbrev=0)
+  # ignore error if no tag
+  J9_TAG=$(git -C $j9Location describe --abbrev=0 2>/dev/null || true)
   # shellcheck disable=SC2086
   if [ ${BUILD_CONFIG[RELEASE]} = false ]; then
     echo -e OPENJ9_TAG=\"$J9_TAG\" >> release


### PR DESCRIPTION
Set gcc-11.2 compiler for Semeru 19+.
Fix openj9 tag.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>