### PR TITLE
Fix for Adopt API release version query

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -96,7 +96,7 @@ then
     do
         # Use Adopt API to get the JDK Head number
         echo "This appears to be JDK Head. Querying the Adopt API to get the JDK HEAD Number (https://api.adoptium.net/v3/info/available_releases)..."
-        JAVA_FEATURE_VERSION=$(curl -q https://api.adoptium.net/v3/info/available_releases | awk '/tip_version/{print$2}')
+        JAVA_FEATURE_VERSION=$(curl -q -k https://api.adoptium.net/v3/info/available_releases | awk '/tip_version/{print$2}')
 
         # Checks the api request was successful and the return value is a number
         if [ -z "${JAVA_FEATURE_VERSION}" ] || ! [[ "${JAVA_FEATURE_VERSION}" -gt 0 ]]
@@ -113,7 +113,7 @@ then
     if [ -z "${JAVA_FEATURE_VERSION}" ] || ! [[ "${JAVA_FEATURE_VERSION}" -gt 0 ]]
     then
         echo "Failed ${retryCount} times to query or parse the adopt api. Dumping headers via curl -v https://api.adoptium.net/v3/info/available_releases and exiting..."
-        curl -v https://api.adoptium.net/v3/info/available_releases
+        curl -v -k https://api.adoptium.net/v3/info/available_releases
         echo curl returned RC $? in make_adopt_build_farm.sh
         exit 1
     fi

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -43,7 +43,7 @@ function setOpenJdkVersion() {
     do
         # Use Adopt API to get the JDK Head number
         echo "This appears to be JDK Head. Querying the Adopt API to get the JDK HEAD Number (https://api.adoptium.net/v3/info/available_releases)..."
-        local featureNumber=$(curl -q https://api.adoptium.net/v3/info/available_releases | awk '/tip_version/{print$2}')
+        local featureNumber=$(curl -q -k https://api.adoptium.net/v3/info/available_releases | awk '/tip_version/{print$2}')
         
         # Checks the api request was successful and the return value is a number
         if [ -z "${featureNumber}" ] || ! [[ "${featureNumber}" -gt 0 ]]
@@ -60,7 +60,7 @@ function setOpenJdkVersion() {
     if [ -z "${featureNumber}" ] || ! [[ "${featureNumber}" -gt 0 ]]
     then
         echo "Failed ${retryCount} times to query or parse the adopt api. Dumping headers via curl -v https://api.adoptium.net/v3/info/available_releases and exiting..."
-        curl -v https://api.adoptium.net/v3/info/available_releases
+        curl -v -k https://api.adoptium.net/v3/info/available_releases
         echo curl returned RC $? in common.sh
         exit 1
     fi


### PR DESCRIPTION
Add insecure option to curl command  to avoid failures due to Let's
Encrypt DST Root CA X3 Expiration(Sept 2021) on systems with older root
certificate.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>