### PR TITLE
Use openssl 1.1.1q with macOS fix from github.com/ibmruntimes/openssl

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -263,7 +263,7 @@ updateOpenj9Sources() {
   if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_OPENJ9}" ]; then
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}" || return
     # NOTE: fetched openssl will NOT be used in the RISC-V cross-compile situation
-    bash get_source.sh --openssl-version=1.1.1p
+    bash get_source.sh --openssl-repo=https://github.com/ibmruntimes/openssl.git --openssl-version=1.1.1q4mac
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}"
   fi
 }


### PR DESCRIPTION
Depends on updates to support the --openssl-repo option, https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/624 and the other versions linked from there. Also depends on https://github.com/ibmruntimes/openssl being populated.

Temporary change to use OpenSSL 1.1.1q until 1.1.1s is available. The 1.1.1r release was withdrawn. 
https://mta.openssl.org/pipermail/openssl-announce/2022-October/000237.html
