### PR TITLE
Update OpenSSL to the 1.1.1 July 19 CVE level

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -279,7 +279,7 @@ updateOpenj9Sources() {
   if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_OPENJ9}" ]; then
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}" || return
     # NOTE: fetched openssl will NOT be used in the RISC-V cross-compile situation
-    bash get_source.sh --openssl-version=1.1.1u
+    bash get_source.sh --openssl-version=OpenSSL_1_1_1u+CVEs --openssl-repo=https://github.com/ibmruntimes/openssl.git
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}"
   fi
 }


### PR DESCRIPTION
Includes fix for CVE-2023-3446.

Port of https://github.com/eclipse-openj9/openj9/pull/17828