### PR TITLE
sets cuda ver to 12.2.0 in specific-conf/linux.sh

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -220,7 +220,7 @@ then
 
   if [ "${ARCHITECTURE}" == "ppc64le" ] || [ "${ARCHITECTURE}" == "x64" ]
   then
-    CUDA_VERSION=9.0
+    CUDA_VERSION=12.2.0
     CUDA_HOME=/usr/local/cuda-$CUDA_VERSION
     if [ -f $CUDA_HOME/include/cuda.h ]
     then


### PR DESCRIPTION
Revert cuda workaround in Semeru build+ sets cuda ver to 12.2.0 linux.sh

Sign-off-by: mahdi@ibm.com