### PR TITLE
Update OpenSSL version to include fix for CVE-2023-4807

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -280,7 +280,7 @@ updateOpenj9Sources() {
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}" || return
     # NOTE: fetched openssl will NOT be used in the RISC-V cross-compile situation
     if [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" = *"cygwin"* ]] || [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "darwin" ]]; then
-      bash get_source.sh --openssl-version=3.0.10
+      bash get_source.sh --openssl-version=openssl-3.0.10+CVEs1 --openssl-repo=https://github.com/ibmruntimes/openssl.git
     else
       # Continue using 1.1.1 until all platforms can build 3.0.10
       bash get_source.sh --openssl-version=1.1.1v


### PR DESCRIPTION
This only updates 3.0.10 since this is the only version which is bundled. 1.1.1v is sufficient to build against for other platforms, it's not used at runtime.

See also https://github.com/eclipse-openj9/openj9/pull/18108