### PR TITLE
Set OpenJ9 compilers, Win VS2022, x,p,zlinux gcc 11.2, alinux gcc 10.3

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -319,6 +319,18 @@ elif [ "$JAVA_FEATURE_VERSION" -ge 19 ] && [ -r /usr/local/gcc11/bin/gcc-11.2 ] 
   [ -r /usr/local/gcc11/bin/gcc-11.2 ] && export  CC=/usr/local/gcc11/bin/gcc-11.2
   [ -r /usr/local/gcc11/bin/g++-11.2 ] && export CXX=/usr/local/gcc11/bin/g++-11.2
   export LD_LIBRARY_PATH=/usr/local/gcc11/lib64:/usr/local/gcc11/lib
+elif [ -r /usr/local/gcc11/bin/gcc-11.2 ] && [ "${ARCHITECTURE}" != "aarch64" ] && [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ] ; then
+  # For OpenJ9 use gcc 11.2 except on aarch64 Linux, due to https://github.com/eclipse-openj9/openj9/issues/15390
+  export PATH=/usr/local/gcc11/bin:$PATH
+  [ -r /usr/local/gcc11/bin/gcc-11.2 ] && export  CC=/usr/local/gcc11/bin/gcc-11.2
+  [ -r /usr/local/gcc11/bin/g++-11.2 ] && export CXX=/usr/local/gcc11/bin/g++-11.2
+  export LD_LIBRARY_PATH=/usr/local/gcc11/lib64:/usr/local/gcc11/lib
+elif [ -r /usr/local/gcc10/bin/gcc-10.3 ] && [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ] ; then
+  # For OpenJ9 use gcc 10.3 on aarch64 Linux
+  export PATH=/usr/local/gcc10/bin:$PATH
+  [ -r /usr/local/gcc10/bin/gcc-10.3 ] && export  CC=/usr/local/gcc10/bin/gcc-10.3
+  [ -r /usr/local/gcc10/bin/g++-10.3 ] && export CXX=/usr/local/gcc10/bin/g++-10.3
+  export LD_LIBRARY_PATH=/usr/local/gcc10/lib64:/usr/local/gcc10/lib
 elif [ "$JAVA_FEATURE_VERSION" -ge 17 ] && [ -r /usr/local/gcc10/bin/gcc-10.3 ]; then
   export PATH=/usr/local/gcc10/bin:$PATH
   [ -r /usr/local/gcc10/bin/gcc-10.3 ] && export  CC=/usr/local/gcc10/bin/gcc-10.3

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -116,13 +116,13 @@ then
   then
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched --enable-openssl-bundling"
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-msvcp-dll=/cygdrive/c/Windows/SysWOW64/msvcp140.dll --with-msvcr-dll=/cygdrive/c/Windows/SysWOW64/vcruntime140.dll"
+    TOOLCHAIN_VERSION="2022"
     if [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ]
     then
       export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
       # https://github.com/adoptium/temurin-build/issues/243
       export INCLUDE="C:\Program Files\Debugging Tools for Windows (x64)\sdk\inc;$INCLUDE"
       export PATH="/c/cygwin64/bin:/usr/bin:$PATH"
-      TOOLCHAIN_VERSION="2019"
     elif [ "${JAVA_TO_BUILD}" == "${JDK11_VERSION}" ]
     then
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-freemarker-jar=/cygdrive/c/openjdk/freemarker.jar"
@@ -164,28 +164,13 @@ then
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-msvcp-dll=/cygdrive/c/Windows/System32/msvcp140.dll --with-msvcr-dll=/cygdrive/c/Windows/System32/vcruntime140.dll"
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-vcruntime-1-dll=/cygdrive/c/Windows/System32/vcruntime140_1.dll"
+    TOOLCHAIN_VERSION="2022"
+    export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
 
     if [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ]
     then
       export INCLUDE="C:\Program Files\Debugging Tools for Windows (x64)\sdk\inc;$INCLUDE"
       export PATH="$PATH:/c/cygwin64/bin"
-      export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
-      TOOLCHAIN_VERSION="2019"
-    elif [ "${JAVA_TO_BUILD}" == "${JDK9_VERSION}" ]
-    then
-      TOOLCHAIN_VERSION="2013"
-      export BUILD_ARGS="${BUILD_ARGS} --freetype-version 2.5.3"
-    elif [ "${JAVA_TO_BUILD}" == "${JDK10_VERSION}" ]
-    then
-      export BUILD_ARGS="${BUILD_ARGS} --freetype-version 2.5.3"
-    elif [ "$JAVA_FEATURE_VERSION" -lt 19 ]
-    then
-      TOOLCHAIN_VERSION="2019"
-      export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
-    elif [ "$JAVA_FEATURE_VERSION" -ge 19 ]
-    then
-      TOOLCHAIN_VERSION="2022"
-      export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
     fi
 
     CUDA_VERSION=9.0


### PR DESCRIPTION
Affects jdk8, jdk11, jdk17, although jdk17 alinux doesn't change.
OpenJ9 jdk8, jdk11 xlinux hasn't switched to gcc 11.2 yet since the
container used to compile doesn't yet contain this compiler.

See
https://github.com/eclipse-openj9/openj9/pull/18135
https://github.com/eclipse-openj9/openj9/pull/18408

This is for 24_01 +