### PR TITLE
Update to openssl 3.0.12

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -279,7 +279,7 @@ updateOpenj9Sources() {
   if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_OPENJ9}" ]; then
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}" || return
     # NOTE: fetched openssl will NOT be used in the RISC-V cross-compile situation
-    bash get_source.sh --openssl-version=3.0.11
+    bash get_source.sh --openssl-version=3.0.12
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}"
   fi
 }


### PR DESCRIPTION
Cherry-pick https://github.com/adoptium/temurin-build/pull/3512 for IBM.