### PR TITLE
Bundle OpenJCEPlus and get GSKit binaries from Artifactory

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -125,6 +125,13 @@ if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
   else
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched"
   fi
+
+  if [ "$JAVA_FEATURE_VERSION" -eq 17 ]; then
+    # Add extra flag if OpenJCEPlus is to be bundled
+    if [[ $BUILD_ARGS == *"--bundle-openjceplus"* ]]; then
+      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-openjceplus"
+    fi
+  fi
 else
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} DF=/usr/sysv/bin/df"
 fi

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -243,8 +243,7 @@ then
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-cuda --with-cuda=$CUDA_HOME"
     fi
 
-    if [ "$JAVA_FEATURE_VERSION" -eq 17 ]
-    then
+    if [ "$JAVA_FEATURE_VERSION" -eq 17 ]; then
       if [ "$ARCHITECTURE" = "x64"  ] || [ "$ARCHITECTURE" = "ppc64le"  ]; then
         # Add extra flag if OpenJCEPlus is to be bundled
         if [[ $BUILD_ARGS == *"--bundle-openjceplus"* ]]; then

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -242,6 +242,16 @@ then
     then
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-cuda --with-cuda=$CUDA_HOME"
     fi
+
+    if [ "$JAVA_FEATURE_VERSION" -eq 17 ]
+    then
+      if [ "$ARCHITECTURE" = "x64"  ] || [ "$ARCHITECTURE" = "ppc64le"  ]; then
+        # Add extra flag if OpenJCEPlus is to be bundled
+        if [[ $BUILD_ARGS == *"--bundle-openjceplus"* ]]; then
+          export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-openjceplus"
+        fi
+      fi
+    fi
   fi
 fi
 

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -161,6 +161,15 @@ then
   then
     export HAS_AUTOCONF=1
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched --enable-openssl-bundling"
+
+    if [ "$JAVA_FEATURE_VERSION" -eq 17 ]
+    then
+      # Add extra flag if OpenJCEPlus is to be bundled
+      if [[ $BUILD_ARGS == *"--bundle-openjceplus"* ]]; then
+        export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-openjceplus"
+      fi
+    fi
+
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-msvcp-dll=/cygdrive/c/Windows/System32/msvcp140.dll --with-msvcr-dll=/cygdrive/c/Windows/System32/vcruntime140.dll"
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-vcruntime-1-dll=/cygdrive/c/Windows/System32/vcruntime140_1.dll"

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -162,8 +162,7 @@ then
     export HAS_AUTOCONF=1
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched --enable-openssl-bundling"
 
-    if [ "$JAVA_FEATURE_VERSION" -eq 17 ]
-    then
+    if [ "$JAVA_FEATURE_VERSION" -eq 17 ]; then
       # Add extra flag if OpenJCEPlus is to be bundled
       if [[ $BUILD_ARGS == *"--bundle-openjceplus"* ]]; then
         export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-openjceplus"

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -223,6 +223,9 @@ function parseConfigurationArguments() {
         "--build-number"  | "-B" )
         BUILD_CONFIG[OPENJDK_BUILD_NUMBER]="$1"; shift;;
 
+        " --bundle-openjceplus" )
+        BUILD_CONFIG[BUNDLE_OPENJCEPLUS]=true;;
+
         "--configure-args"  | "-C" )
         BUILD_CONFIG[USER_SUPPLIED_CONFIGURE_ARGS]="$1"; shift;;
 

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -286,8 +286,33 @@ updateOpenj9Sources() {
   # Building OpenJDK with OpenJ9 must run get_source.sh to clone openj9 and openj9-omr repositories
   if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_OPENJ9}" ]; then
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}" || return
+
+    if [ "$JAVA_FEATURE_VERSION" -eq 17 ]
+    then
+      if [ "${BUILD_CONFIG[BUNDLE_OPENJCEPLUS]}" == "true" ]; then
+        # Set the flags to get the OpenJCEPlus source code
+        OPENJCEPLUS_FLAGS="-openjceplus-repo=https://github.com/ibmruntimes/OpenJCEPlus.git -openjceplus-branch=semeru-main"
+        # Set the flags to get the appropriate GSKit binaries
+        GSKIT_FOLDER="https://na.artifactory.swg-devops.com/artifactory/sec-gskit-javasec-generic-local/gskit8/20230802_8.9.5"
+        if [ "$TARGET_OS" = "linux"  ]; then
+          if [ "$ARCHITECTURE" = "x64"  ]; then
+            GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/linux64_x86/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/linux64_x86/jgsk_crypto_sdk.tar"
+          elif [ "$ARCHITECTURE" = "ppc64le"  ]; then
+            GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/linux64_ppcle/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/linux64_ppcle/jgsk_crypto_sdk.tar"
+          fi
+        fi
+        if [ "$TARGET_OS" = "aix"  ]; then
+          GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/aix64_ppc/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/aix64_ppc/jgsk_crypto_sdk.tar"
+        fi
+        if [ "$TARGET_OS" = "windows"  ]; then
+          GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/win64_x86/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/win64_x86/jgsk_crypto_sdk.tar"
+        fi
+        GSKIT_CREDENTIALS="\$GSKIT_USERNAME:\$GSKIT_PASSWORD"
+      fi
+    fi
+    
     # NOTE: fetched openssl will NOT be used in the RISC-V cross-compile situation
-    bash get_source.sh --openssl-version=openssl-3.0.12+CVEs1 --openssl-repo=https://github.com/ibmruntimes/openssl.git
+    bash get_source.sh --openssl-version=openssl-3.0.12+CVEs1 --openssl-repo=https://github.com/ibmruntimes/openssl.git "${OPENJCEPLUS_FLAGS} ${GSKIT_FLAGS} ${GSKIT_CREDENTIALS}"
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}"
   fi
 }

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -286,25 +286,31 @@ updateOpenj9Sources() {
   # Building OpenJDK with OpenJ9 must run get_source.sh to clone openj9 and openj9-omr repositories
   if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_OPENJ9}" ]; then
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}" || return
-
+OPENJCEPLUS_FLAGS=""
+GSKIT_FLAGS=""
+GSKIT_CREDENTIALS=""
     if [ "$JAVA_FEATURE_VERSION" -eq 17 ]
     then
       if [ "${BUILD_CONFIG[BUNDLE_OPENJCEPLUS]}" == "true" ]; then
         # Set the flags to get the OpenJCEPlus source code
-        OPENJCEPLUS_FLAGS="-openjceplus-repo=https://github.com/ibmruntimes/OpenJCEPlus.git -openjceplus-branch=semeru-main"
+        OPENJDKPLUS_BRANCH="semeru-main"
         # Set the flags to get the appropriate GSKit binaries
         GSKIT_FOLDER="https://na.artifactory.swg-devops.com/artifactory/sec-gskit-javasec-generic-local/gskit8/20230802_8.9.5"
         if [ "$TARGET_OS" = "linux"  ]; then
           if [ "$ARCHITECTURE" = "x64"  ]; then
+            OPENJCEPLUS_FLAGS="-openjceplus-repo=https://github.com/ibmruntimes/OpenJCEPlus.git -openjceplus-branch=${OPENJDKPLUS_BRANCH}"
             GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/linux64_x86/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/linux64_x86/jgsk_crypto_sdk.tar"
           elif [ "$ARCHITECTURE" = "ppc64le"  ]; then
+            OPENJCEPLUS_FLAGS="-openjceplus-repo=https://github.com/ibmruntimes/OpenJCEPlus.git -openjceplus-branch=${OPENJDKPLUS_BRANCH}"
             GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/linux64_ppcle/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/linux64_ppcle/jgsk_crypto_sdk.tar"
           fi
         fi
         if [ "$TARGET_OS" = "aix"  ]; then
+          OPENJCEPLUS_FLAGS="-openjceplus-repo=https://github.com/ibmruntimes/OpenJCEPlus.git -openjceplus-branch=${OPENJDKPLUS_BRANCH}"
           GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/aix64_ppc/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/aix64_ppc/jgsk_crypto_sdk.tar"
         fi
         if [ "$TARGET_OS" = "windows"  ]; then
+          OPENJCEPLUS_FLAGS="-openjceplus-repo=https://github.com/ibmruntimes/OpenJCEPlus.git -openjceplus-branch=${OPENJDKPLUS_BRANCH}"
           GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/win64_x86/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/win64_x86/jgsk_crypto_sdk.tar"
         fi
         GSKIT_CREDENTIALS="\$GSKIT_USERNAME:\$GSKIT_PASSWORD"


### PR DESCRIPTION
The appropriate flags are added to clone the `OpenJCEPlus` repo and get the proper `GSKit` binaries that are required in each platform, as part of preparing the workspace.

The corresponding flag to bundle `OpenJCEPlus` is, also,  added to the ones supplied to the `configure` script in each platform.

In all cases, the Java version is ensured to be 17, since `OpenJCEPlus` is only supported there for the time being.

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)