### PR TITLE
Update to openssl 3.0.13

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -322,7 +322,7 @@ updateOpenj9Sources() {
     fi
     
     # NOTE: fetched openssl will NOT be used in the RISC-V cross-compile situation
-    bash get_source.sh --openssl-version=openssl-3.0.12+CVEs4 --openssl-repo=https://github.com/ibmruntimes/openssl.git ${OPENJCEPLUS_FLAGS} ${GSKIT_FLAGS} ${GSKIT_CREDENTIALS}
+    bash get_source.sh --openssl-version=3.0.13 ${OPENJCEPLUS_FLAGS} ${GSKIT_FLAGS} ${GSKIT_CREDENTIALS}
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}"
   fi
 }


### PR DESCRIPTION
Cherry-pick https://github.com/adoptium/temurin-build/pull/3626 for IBM.