### PR TITLE
Add s390x architecture and change branch to bundle OpenJCEPlus versions

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -126,11 +126,9 @@ if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched"
   fi
 
-  if [ "$JAVA_FEATURE_VERSION" -eq 17 ]; then
-    # Add extra flag if OpenJCEPlus is to be bundled
-    if [[ $BUILD_ARGS == *"--bundle-openjceplus"* ]]; then
-      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-openjceplus"
-    fi
+  # Add extra flag if OpenJCEPlus is to be bundled
+  if [[ $BUILD_ARGS == *"--bundle-openjceplus"* ]]; then
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-openjceplus"
   fi
 else
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} DF=/usr/sysv/bin/df"

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -251,14 +251,12 @@ then
     then
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-cuda --with-cuda=$CUDA_HOME"
     fi
+  fi
 
-    if [ "$JAVA_FEATURE_VERSION" -eq 17 ]; then
-      if [ "$ARCHITECTURE" = "x64"  ] || [ "$ARCHITECTURE" = "ppc64le"  ]; then
-        # Add extra flag if OpenJCEPlus is to be bundled
-        if [[ $BUILD_ARGS == *"--bundle-openjceplus"* ]]; then
-          export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-openjceplus"
-        fi
-      fi
+  if [ "$ARCHITECTURE" = "ppc64le"  ] || [ "${ARCHITECTURE}" == "s390x" ] || [ "$ARCHITECTURE" = "x64"  ]; then
+    # Add extra flag if OpenJCEPlus is to be bundled
+    if [[ $BUILD_ARGS == *"--bundle-openjceplus"* ]]; then
+      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-openjceplus"
     fi
   fi
 fi

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -162,11 +162,9 @@ then
     export HAS_AUTOCONF=1
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched --enable-openssl-bundling"
 
-    if [ "$JAVA_FEATURE_VERSION" -eq 17 ]; then
-      # Add extra flag if OpenJCEPlus is to be bundled
-      if [[ $BUILD_ARGS == *"--bundle-openjceplus"* ]]; then
-        export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-openjceplus"
-      fi
+    # Add extra flag if OpenJCEPlus is to be bundled
+    if [[ $BUILD_ARGS == *"--bundle-openjceplus"* ]]; then
+      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-openjceplus"
     fi
 
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -290,34 +290,45 @@ updateOpenj9Sources() {
     OPENJCEPLUS_FLAGS=""
     GSKIT_FLAGS=""
     GSKIT_CREDENTIALS=""
-    if [ "$JAVA_FEATURE_VERSION" -eq 17 ]
-    then
-      if [ "${BUILD_CONFIG[BUNDLE_OPENJCEPLUS]}" == "true" ]; then
+    
+    if [ "${BUILD_CONFIG[BUNDLE_OPENJCEPLUS]}" == "true" ]; then
+      SUPPORTED_PLATFORM=false
+      if [ "$TARGET_OS" = "linux"  ]; then
+        if [ "$ARCHITECTURE" = "x64" ] || [ "$ARCHITECTURE" = "ppc64le" ] || [ "$ARCHITECTURE" = "s390x"  ]; then
+          SUPPORTED_PLATFORM=true
+        fi
+      elif [ "$TARGET_OS" = "aix" ] || [ "$TARGET_OS" = "windows" ]; then
+          SUPPORTED_PLATFORM=true
+      fi
+
+      if [ "$SUPPORTED_PLATFORM" == "true" ]; then
         # Set the flags to get the OpenJCEPlus source code
-        OPENJCEPLUS_BRANCH="semeru-main"
-        # Set the flags to get the appropriate GSKit binaries
-        GSKIT_FOLDER="https://na.artifactory.swg-devops.com/artifactory/sec-gskit-javasec-generic-local/gskit8/20230802_8.9.5"
-        if [ "$TARGET_OS" = "linux"  ]; then
-          if [ "$ARCHITECTURE" = "x64"  ]; then
-            OPENJCEPLUS_FLAGS="-openjceplus-repo=https://github.com/ibmruntimes/OpenJCEPlus.git -openjceplus-branch=${OPENJCEPLUS_BRANCH}"
-            GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/linux64_x86/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/linux64_x86/jgsk_crypto_sdk.tar"
-            GSKIT_CREDENTIALS="-gskit-credential=$GSKIT_USERNAME:$GSKIT_PASSWORD"
-          elif [ "$ARCHITECTURE" = "ppc64le"  ]; then
-            OPENJCEPLUS_FLAGS="-openjceplus-repo=https://github.com/ibmruntimes/OpenJCEPlus.git -openjceplus-branch=${OPENJCEPLUS_BRANCH}"
-            GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/linux64_ppcle/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/linux64_ppcle/jgsk_crypto_sdk.tar"
-            GSKIT_CREDENTIALS="-gskit-credential=$GSKIT_USERNAME:$GSKIT_PASSWORD"
-          fi
-        fi
-        if [ "$TARGET_OS" = "aix"  ]; then
-          OPENJCEPLUS_FLAGS="-openjceplus-repo=https://github.com/ibmruntimes/OpenJCEPlus.git -openjceplus-branch=${OPENJCEPLUS_BRANCH}"
-          GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/aix64_ppc/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/aix64_ppc/jgsk_crypto_sdk.tar"
+        OPENJCEPLUS_BRANCH="semeru-java$JAVA_FEATURE_VERSION"
+        OPENJCEPLUS_FLAGS="-openjceplus-repo=https://github.com/ibmruntimes/OpenJCEPlus.git -openjceplus-branch=${OPENJCEPLUS_BRANCH}"
+      fi
+      
+      
+      # Set the flags to get the appropriate GSKit binaries
+      GSKIT_FOLDER="https://na.artifactory.swg-devops.com/artifactory/sec-gskit-javasec-generic-local/gskit8/20230802_8.9.5"
+      if [ "$TARGET_OS" = "linux"  ]; then
+        if [ "$ARCHITECTURE" = "x64"  ]; then
+          GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/linux64_x86/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/linux64_x86/jgsk_crypto_sdk.tar"
+          GSKIT_CREDENTIALS="-gskit-credential=$GSKIT_USERNAME:$GSKIT_PASSWORD"
+        elif [ "$ARCHITECTURE" = "ppc64le"  ]; then
+          GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/linux64_ppcle/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/linux64_ppcle/jgsk_crypto_sdk.tar"
+          GSKIT_CREDENTIALS="-gskit-credential=$GSKIT_USERNAME:$GSKIT_PASSWORD"
+        elif [ "$ARCHITECTURE" = "s390x"  ]; then
+          GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/linux64_s390/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/linux64_s390/jgsk_crypto_sdk.tar"
           GSKIT_CREDENTIALS="-gskit-credential=$GSKIT_USERNAME:$GSKIT_PASSWORD"
         fi
-        if [ "$TARGET_OS" = "windows"  ]; then
-          OPENJCEPLUS_FLAGS="-openjceplus-repo=https://github.com/ibmruntimes/OpenJCEPlus.git -openjceplus-branch=${OPENJCEPLUS_BRANCH}"
-          GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/win64_x86/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/win64_x86/jgsk_crypto_sdk.tar"
-          GSKIT_CREDENTIALS="-gskit-credential=$GSKIT_USERNAME:$GSKIT_PASSWORD"
-        fi
+      fi
+      if [ "$TARGET_OS" = "aix"  ]; then
+        GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/aix64_ppc/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/aix64_ppc/jgsk_crypto_sdk.tar"
+        GSKIT_CREDENTIALS="-gskit-credential=$GSKIT_USERNAME:$GSKIT_PASSWORD"
+      fi
+      if [ "$TARGET_OS" = "windows"  ]; then
+        GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/win64_x86/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/win64_x86/jgsk_crypto_sdk.tar"
+        GSKIT_CREDENTIALS="-gskit-credential=$GSKIT_USERNAME:$GSKIT_PASSWORD"
       fi
     fi
     


### PR DESCRIPTION
The architectures to bundle `OpenJCEPlus` with is extended to include `s390x`.

The checks for specific Java version are also removed, since the flags to bundle are only passed for the appropriate versions

The branch used to clone `OpenJCEPlus` is not hard-coded anymore, but rather inferred based on Java version.

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com) 