### PR TITLE
fixes the unknown param issue in build pipelines

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -334,7 +334,7 @@ updateOpenj9Sources() {
     fi
     
     # NOTE: fetched openssl will NOT be used in the RISC-V cross-compile situation
-    bash get_source.sh --openssl-version=openssl-3.0.13+CVEs1 --openssl-repo=https://github.com/ibmruntimes/openssl.git ${OPENJCEPLUS_FLAGS} ${GSKIT_FLAGS} ${GSKIT_CREDENTIALS}
+    bash get_source.sh -openssl-branch=openssl-3.0.13+CVEs1 -openssl-repo=https://github.com/ibmruntimes/openssl.git ${OPENJCEPLUS_FLAGS} ${GSKIT_FLAGS} ${GSKIT_CREDENTIALS}
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}"
   fi
 }


### PR DESCRIPTION
the option openssl-version replaced with -openssl-branch and need to reflect same here to avoid pipelines fail with Unkown praram -openssl-version