### PR TITLE
Update pipeline to use latest GSKit binaries

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -393,25 +393,28 @@ updateOpenj9Sources() {
       
       
       # Set the flags to get the appropriate GSKit binaries
-      GSKIT_FOLDER="https://na.artifactory.swg-devops.com/artifactory/sec-gskit-javasec-generic-local/gskit8/20230802_8.9.5"
+      GSKIT_FOLDER="https://na.artifactory.swg-devops.com/artifactory/sec-gskit-javasec-generic-local/gskit8"
+      GSKIT_VERSION="20240521_8.9.6"
+      GSKIT_LOCATION="${GSKIT_FOLDER}/${GSKIT_VERSION}"
+      GSKIT_PLATFORM=""
       if [ "$TARGET_OS" = "linux"  ]; then
         if [ "$ARCHITECTURE" = "x64"  ]; then
-          GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/linux64_x86/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/linux64_x86/jgsk_crypto_sdk.tar"
-          GSKIT_CREDENTIALS="-gskit-credential=$GSKIT_USERNAME:$GSKIT_PASSWORD"
+          GSKIT_PLATFORM="linux64_x86"
         elif [ "$ARCHITECTURE" = "ppc64le"  ]; then
-          GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/linux64_ppcle/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/linux64_ppcle/jgsk_crypto_sdk.tar"
-          GSKIT_CREDENTIALS="-gskit-credential=$GSKIT_USERNAME:$GSKIT_PASSWORD"
+          GSKIT_PLATFORM="linux64_ppcle"
         elif [ "$ARCHITECTURE" = "s390x"  ]; then
-          GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/linux64_s390/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/linux64_s390/jgsk_crypto_sdk.tar"
-          GSKIT_CREDENTIALS="-gskit-credential=$GSKIT_USERNAME:$GSKIT_PASSWORD"
+          GSKIT_PLATFORM="linux64_s390"
         fi
       fi
       if [ "$TARGET_OS" = "aix"  ]; then
-        GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/aix64_ppc/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/aix64_ppc/jgsk_crypto_sdk.tar"
-        GSKIT_CREDENTIALS="-gskit-credential=$GSKIT_USERNAME:$GSKIT_PASSWORD"
+        GSKIT_PLATFORM="aix64_ppc"
       fi
       if [ "$TARGET_OS" = "windows"  ]; then
-        GSKIT_FLAGS="-gskit-bin=${GSKIT_FOLDER}/win64_x86/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_FOLDER}/win64_x86/jgsk_crypto_sdk.tar"
+        GSKIT_PLATFORM="win64_x86"
+      fi
+
+      if [ "$SUPPORTED_PLATFORM" == "true" ]; then
+        GSKIT_FLAGS="-gskit-bin=${GSKIT_LOCATION}/${GSKIT_PLATFORM}/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_LOCATION}/${GSKIT_PLATFORM}/jgsk_crypto_sdk.tar"
         GSKIT_CREDENTIALS="-gskit-credential=$GSKIT_USERNAME:$GSKIT_PASSWORD"
       fi
     fi


### PR DESCRIPTION
With this update the pipeline will use the latest `GSKit` binaries.

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>