### PR TITLE
Update OpenSSL 3.0.14 to include the fix for CVE-2024-5535

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -420,7 +420,7 @@ updateOpenj9Sources() {
     fi
     
     # NOTE: fetched openssl will NOT be used in the RISC-V cross-compile situation
-    bash get_source.sh --openssl-version=3.0.14 ${OPENJCEPLUS_FLAGS} ${GSKIT_FLAGS} ${GSKIT_CREDENTIALS}
+    bash get_source.sh --openssl-version=3.0.14+CVEs1 --openssl-repo=https://github.com/ibmruntimes/openssl.git ${OPENJCEPLUS_FLAGS} ${GSKIT_FLAGS} ${GSKIT_CREDENTIALS}
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}"
   fi
 }


### PR DESCRIPTION
See also https://github.com/eclipse-openj9/openj9/pull/19776