### PR TITLE
Bootjdk for 23 on xmac use 21

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -101,6 +101,11 @@ if [ "${JDK_BOOT_VERSION}" == "7" ]; then
   echo "No jdk7 boot JDK available on MacOS using jdk8"
   JDK_BOOT_VERSION="8"
 fi
+# xmac can't run jdk22 on mac10. Build 23 with 21 for now
+if [[ "${JDK_BOOT_VERSION}" == "22" ] && [ "${ARCHITECTURE}" == "x64" ]]; then
+  echo "jdk22 boot JDK can't run on mac10 compile machines"
+  JDK_BOOT_VERSION="21"
+fi
 BOOT_JDK_VARIABLE="JDK${JDK_BOOT_VERSION}_BOOT_DIR"
 if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
   bootDir="$PWD/jdk-$JDK_BOOT_VERSION"


### PR DESCRIPTION
related infra 9475
JDK22 can't run on macos10