### PR TITLE
Update to openssl 3.0.15

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -420,7 +420,7 @@ updateOpenj9Sources() {
     fi
     
     # NOTE: fetched openssl will NOT be used in the RISC-V cross-compile situation
-    bash get_source.sh --openssl-version=3.0.14 ${OPENJCEPLUS_FLAGS} ${GSKIT_FLAGS} ${GSKIT_CREDENTIALS}
+    bash get_source.sh -openssl-branch=openssl-3.0.15 ${OPENJCEPLUS_FLAGS} ${GSKIT_FLAGS} ${GSKIT_CREDENTIALS}
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}"
   fi
 }


### PR DESCRIPTION
Cherry-pick https://github.com/adoptium/temurin-build/pull/3935 for the ibm branch.