### PR TITLE
Add the vendor version to the release file

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -2225,6 +2225,8 @@ addInfoToReleaseFile() {
   addFullVersion
   echo "ADDING SEM VER"
   addSemVer
+  echo "ADDING VENDOR VER"
+  addVendorVer
   echo "ADDING BUILD OS"
   addBuildOS
   echo "ADDING VARIANT"
@@ -2345,6 +2347,10 @@ addSemVer() { # Pulls the semantic version from the tag associated with the open
   fi
   # shellcheck disable=SC2086
   echo -e SEMANTIC_VERSION=\"$SEM_VER\" >> release
+}
+
+addVendorVer() {
+  echo -e VENDOR_VERSION=\"${BUILD_CONFIG[VENDOR_VERSION]}\" >> release
 }
 
 # Disable shellcheck in here as it causes issues with ls on mac


### PR DESCRIPTION
There is a JVM_VERSION in the release file, but this may or may not change in a point release. Add the vendor (IBM/Semeru) version which changes for every release.

Related to https://community.ibm.com/community/user/wasdevops/discussion/arp-name-and-display-version-is-not-getting-updated#bm4ea61924-f969-437b-a145-1c134217d974