### PR TITLE
Revert "Add the vendor version to the release file"

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -2225,8 +2225,6 @@ addInfoToReleaseFile() {
   addFullVersion
   echo "ADDING SEM VER"
   addSemVer
-  echo "ADDING VENDOR VER"
-  addVendorVer
   echo "ADDING BUILD OS"
   addBuildOS
   echo "ADDING VARIANT"
@@ -2347,10 +2345,6 @@ addSemVer() { # Pulls the semantic version from the tag associated with the open
   fi
   # shellcheck disable=SC2086
   echo -e SEMANTIC_VERSION=\"$SEM_VER\" >> release
-}
-
-addVendorVer() {
-  echo -e VENDOR_VERSION=\"${BUILD_CONFIG[VENDOR_VERSION]}\" >> release
 }
 
 # Disable shellcheck in here as it causes issues with ls on mac


### PR DESCRIPTION
This reverts commit 7855c35169b15ff7bd355ed530a742114b6d010f.

See https://github.com/ibmruntimes/temurin-build/pull/144#issuecomment-2403420894