### PR TITLE
Add the vendor version to the jdk8 release file

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -2250,6 +2250,9 @@ addImplementor() {
   if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ]; then
     # shellcheck disable=SC2086
     echo -e IMPLEMENTOR=\"${BUILD_CONFIG[VENDOR]}\" >>release
+    if [ -n "${BUILD_CONFIG[VENDOR_VERSION]}" ]; then
+      echo -e IMPLEMENTOR_VERSION=\"${BUILD_CONFIG[VENDOR_VERSION]}\" >>release
+    fi
   fi
 }
 


### PR DESCRIPTION
jdk11 and above add IMPLEMENTOR_VERSION to the "release" file. Add the same for jdk8, from the --vendor-version build argument.

Related to
https://community.ibm.com/community/user/wasdevops/discussion/arp-name-and-display-version-is-not-getting-updated#bm4ea61924-f969-437b-a145-1c134217d974