### PR TITLE
fixes bootjdk sig file download issue

### DIFF
--- a/sbin/common/downloaders.sh
+++ b/sbin/common/downloaders.sh
@@ -71,7 +71,7 @@ function downloadLinuxBootJDK() {
     set +e
     curl -L -o bootjdk.tar.gz "${apiURL}"
     if ! grep "No releases match the request" bootjdk.tar.gz; then
-      apiSigURL=$(curl -v "${apiURL}" 2>&1 | tr -d \\r | awk '/^< Location:/{print $3 ".sig"}')
+      apiSigURL=$(curl -v "${apiURL}" 2>&1 | tr -d \\r | awk '/^< [Ll]ocation:/{print $3 ".sig"}')
       curl -L -o bootjdk.tar.gz.sig "${apiSigURL}"
       gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843C48A565F8F04B
       echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key 3B04D753C9050D9A5D343F39843C48A565F8F04B trust;

--- a/sbin/common/downloaders.sh
+++ b/sbin/common/downloaders.sh
@@ -49,7 +49,7 @@ function downloadLinuxBootJDK() {
   # the fallback mechanism, as downloading of the GA binary might fail.
   set +e
   curl -L -o bootjdk.tar.gz "${apiURL}"
-  apiSigURL=$(curl -v "${apiURL}" 2>&1 | tr -d \\r | awk '/^< Location:/{print $3 ".sig"}')
+  apiSigURL=$(curl -v "${apiURL}" 2>&1 | tr -d \\r | awk '/^< [Ll]ocation:/{print $3 ".sig"}')
   if ! grep "No releases match the request" bootjdk.tar.gz; then
     curl -L -o bootjdk.tar.gz.sig "${apiSigURL}"
     gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843C48A565F8F04B


### PR DESCRIPTION
it fixes the issue creating sig file download URL from crl output. Related https://github.ibm.com/runtimes/semeru-releases/issues/48

Signed-off-by: mahdi@ibm.com