### PR TITLE
Update OpenSSL 3.0.15 to include the fix for CVE-2024-13176

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -420,7 +420,7 @@ updateOpenj9Sources() {
     fi
     
     # NOTE: fetched openssl will NOT be used in the RISC-V cross-compile situation
-    bash get_source.sh -openssl-repo=https://github.com/ibmruntimes/openssl.git -openssl-branch=openssl-3.0.15+CVEs1 ${OPENJCEPLUS_FLAGS} ${GSKIT_FLAGS} ${GSKIT_CREDENTIALS}
+    bash get_source.sh -openssl-repo=https://github.com/ibmruntimes/openssl.git -openssl-branch=openssl-3.0.15+CVEs2 ${OPENJCEPLUS_FLAGS} ${GSKIT_FLAGS} ${GSKIT_CREDENTIALS}
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}"
   fi
 }


### PR DESCRIPTION
See also https://github.ibm.com/runtimes/tooling/pull/1192