### PR TITLE
Bundle OpenJCEPlus with non-FIPS platforms

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -221,7 +221,7 @@ then
     fi
   fi
 
-  if [ "$ARCHITECTURE" = "ppc64le"  ] || [ "${ARCHITECTURE}" == "s390x" ] || [ "$ARCHITECTURE" = "x64"  ]; then
+  if [ "$ARCHITECTURE" = "aarch64"  ] || [ "$ARCHITECTURE" = "ppc64le"  ] || [ "${ARCHITECTURE}" == "s390x" ] || [ "$ARCHITECTURE" = "x64"  ]; then
     # Add extra flag if OpenJCEPlus is to be bundled
     if [[ $BUILD_ARGS == *"--bundle-openjceplus"* ]]; then
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-openjceplus"

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -221,11 +221,9 @@ then
     fi
   fi
 
-  if [ "$ARCHITECTURE" = "aarch64"  ] || [ "$ARCHITECTURE" = "ppc64le"  ] || [ "${ARCHITECTURE}" == "s390x" ] || [ "$ARCHITECTURE" = "x64"  ]; then
-    # Add extra flag if OpenJCEPlus is to be bundled
-    if [[ $BUILD_ARGS == *"--bundle-openjceplus"* ]]; then
-      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-openjceplus"
-    fi
+  # Add extra flag if OpenJCEPlus is to be bundled
+  if [[ $BUILD_ARGS == *"--bundle-openjceplus"* ]]; then
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-openjceplus"
   fi
 fi
 

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -166,6 +166,11 @@ if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
     export TAR=gtar
     export SDKPATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
   fi
+
+  # Add extra flag if OpenJCEPlus is to be bundled
+  if [[ $BUILD_ARGS == *"--bundle-openjceplus"* ]]; then
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-openjceplus"
+  fi
 fi
 
 if [ ! "${c_flags_bucket}" = "" ]; then

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -377,20 +377,8 @@ updateOpenj9Sources() {
     GSKIT_CREDENTIALS=""
     
     if [ "${BUILD_CONFIG[BUNDLE_OPENJCEPLUS]}" == "true" ]; then
-      SUPPORTED_PLATFORM=false
-      if [ "$TARGET_OS" = "linux"  ]; then
-        if [ "$ARCHITECTURE" = "x64" ] || [ "$ARCHITECTURE" = "ppc64le" ] || [ "$ARCHITECTURE" = "s390x"  ] || [ "$ARCHITECTURE" = "aarch64"  ]; then
-          SUPPORTED_PLATFORM=true
-        fi
-      elif [ "$TARGET_OS" = "aix" ] || [ "$TARGET_OS" = "windows" ]|| [ "$TARGET_OS" = "mac" ]; then
-          SUPPORTED_PLATFORM=true
-      fi
-
-      if [ "$SUPPORTED_PLATFORM" == "true" ]; then
-        # Set the flags to get the OpenJCEPlus source code
-        OPENJCEPLUS_FLAGS="-openjceplus-repo=https://github.com/ibmruntimes/OpenJCEPlus.git -openjceplus-branch=${BUILD_CONFIG[OPENJCEPLUS_BRANCH]}"
-      fi
-      
+      # Set the flags to get the OpenJCEPlus source code
+      OPENJCEPLUS_FLAGS="-openjceplus-repo=https://github.com/ibmruntimes/OpenJCEPlus.git -openjceplus-branch=${BUILD_CONFIG[OPENJCEPLUS_BRANCH]}"
       
       # Set the flags to get the appropriate GSKit binaries
       GSKIT_FOLDER="https://na.artifactory.swg-devops.com/artifactory/sec-gskit-javasec-generic-local/gskit8"
@@ -422,10 +410,8 @@ updateOpenj9Sources() {
         fi
       fi
 
-      if [ "$SUPPORTED_PLATFORM" == "true" ]; then
-        GSKIT_FLAGS="-gskit-bin=${GSKIT_LOCATION}/${GSKIT_PLATFORM}/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_LOCATION}/${GSKIT_PLATFORM}/jgsk_crypto_sdk.tar"
-        GSKIT_CREDENTIALS="-gskit-credential=$GSKIT_USERNAME:$GSKIT_PASSWORD"
-      fi
+      GSKIT_FLAGS="-gskit-bin=${GSKIT_LOCATION}/${GSKIT_PLATFORM}/jgsk_crypto.tar -gskit-sdk-bin=${GSKIT_LOCATION}/${GSKIT_PLATFORM}/jgsk_crypto_sdk.tar"
+      GSKIT_CREDENTIALS="-gskit-credential=$GSKIT_USERNAME:$GSKIT_PASSWORD"
     fi
     
     # NOTE: fetched openssl will NOT be used in the RISC-V cross-compile situation

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -379,10 +379,10 @@ updateOpenj9Sources() {
     if [ "${BUILD_CONFIG[BUNDLE_OPENJCEPLUS]}" == "true" ]; then
       SUPPORTED_PLATFORM=false
       if [ "$TARGET_OS" = "linux"  ]; then
-        if [ "$ARCHITECTURE" = "x64" ] || [ "$ARCHITECTURE" = "ppc64le" ] || [ "$ARCHITECTURE" = "s390x"  ]; then
+        if [ "$ARCHITECTURE" = "x64" ] || [ "$ARCHITECTURE" = "ppc64le" ] || [ "$ARCHITECTURE" = "s390x"  ] || [ "$ARCHITECTURE" = "aarch64"  ]; then
           SUPPORTED_PLATFORM=true
         fi
-      elif [ "$TARGET_OS" = "aix" ] || [ "$TARGET_OS" = "windows" ]; then
+      elif [ "$TARGET_OS" = "aix" ] || [ "$TARGET_OS" = "windows" ]|| [ "$TARGET_OS" = "mac" ]; then
           SUPPORTED_PLATFORM=true
       fi
 
@@ -404,6 +404,8 @@ updateOpenj9Sources() {
           GSKIT_PLATFORM="linux64_ppcle"
         elif [ "$ARCHITECTURE" = "s390x"  ]; then
           GSKIT_PLATFORM="linux64_s390"
+        elif [ "$ARCHITECTURE" = "aarch64"  ]; then
+          GSKIT_PLATFORM="linux64_arm"
         fi
       fi
       if [ "$TARGET_OS" = "aix"  ]; then
@@ -411,6 +413,13 @@ updateOpenj9Sources() {
       fi
       if [ "$TARGET_OS" = "windows"  ]; then
         GSKIT_PLATFORM="win64_x86"
+      fi
+      if [ "$TARGET_OS" = "mac"  ]; then
+        if [ "$ARCHITECTURE" = "x64"  ]; then
+          GSKIT_PLATFORM="osx64_x86"
+        elif [ "$ARCHITECTURE" = "aarch64"  ]; then
+          GSKIT_PLATFORM="osx64_arm"
+        fi
       fi
 
       if [ "$SUPPORTED_PLATFORM" == "true" ]; then


### PR DESCRIPTION
With this change `OpenJCEPlus` is bundled with the `Semeru JDK` in `aarch64_linux`, `aarch64_mac` and `x86-64_mac`.

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>