### PR TITLE
Enable OpenSSL Version 3.5.0

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -420,7 +420,7 @@ updateOpenj9Sources() {
     fi
     
     # NOTE: fetched openssl will NOT be used in the RISC-V cross-compile situation
-    bash get_source.sh -openssl-branch=openssl-3.0.16 ${OPENJCEPLUS_FLAGS} ${GSKIT_FLAGS} ${GSKIT_CREDENTIALS}
+    bash get_source.sh -openssl-repo=https://github.com/ibmruntimes/openssl.git -openssl-branch=openssl-3.5+SemeruFixes ${OPENJCEPLUS_FLAGS} ${GSKIT_FLAGS} ${GSKIT_CREDENTIALS}
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}"
   fi
 }


### PR DESCRIPTION
This updates to OpenSSL version 3.5.0 ( with fixes necessary for AIX).

Signed-off-by: Jason Katonica <katonica@us.ibm.com>