### PR TITLE
AIX, unset LIBPATH for builds, set the fontconfig location

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -47,9 +47,10 @@ fi
 source "$SCRIPT_DIR/../../sbin/common/constants.sh"
 export PATH="/opt/cmake-3.17.1/bin/:/opt/freeware/bin:/usr/local/bin:/opt/IBM/xlC/13.1.3/bin:/opt/IBM/xlc/13.1.3/bin:$PATH"
 # Without this, java adds /usr/lib to the LIBPATH and it's own library
-# directories of anything it forks which breaks linkage
-export LIBPATH=/opt/freeware/lib/pthread/ppc64:/opt/freeware/lib:/usr/lib
-export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-cups-include=/opt/freeware/include"
+# directories of anything it forks which breaks linkage. Don't set any
+# LIBPATH so tools can find their own dependencies.
+unset LIBPATH
+export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-cups-include=/opt/freeware/include --with-fontconfig-include=/opt/freeware/include"
 
 # Any version below 11
 if  [ "$JAVA_FEATURE_VERSION" -lt 11 ]


### PR DESCRIPTION
See https://github.com/eclipse-openj9/openj9/pull/22908

Some newer tools require either libraries in /opt/freeware/lib or libraries in /usr/lib. If LIBPATH is set, the tools look there first and may find the wrong library. When LIBPATH isn't set, the tools find their libraries in the correct location. Java sets a LIBPATH, so processes created from Java may inherit it, such as processes started from the jenkins agent.

Older fontconfig versions set a symlink to fontconfig.h in /usr/include, but newer versions don't do that.