### PR TITLE
Remove AIX -qnotimestamps for jdk25+ for compatibility with OpenXL

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -132,7 +132,7 @@ configureReproducibleBuildParameter() {
 
       # Ensure reproducible and comparable binary with a unique build user identifier
       addConfigureArg "--with-build-user=" "admin"
-      if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "aix" ]; then
+      if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}"  == "aix" ] && [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -lt 25 ]; then
          addConfigureArg "--with-extra-cflags=" "-qnotimestamps"
          addConfigureArg "--with-extra-cxxflags=" "-qnotimestamps"
       fi


### PR DESCRIPTION
Related to https://github.com/ibmruntimes/temurin-build/pull/205

Builds (with OpenXL) are broken without this.

See https://github.com/adoptium/temurin-build/blob/master/sbin/build.sh#L162