### PR TITLE
Build OpenSSL from the openssl-3.5 branch

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -419,7 +419,7 @@ updateOpenj9Sources() {
     fi
 
     # NOTE: fetched openssl will NOT be used in the RISC-V cross-compile situation
-    bash get_source.sh -openssl-branch=openssl-3.5.5 ${OPENJCEPLUS_FLAGS} ${GSKIT_FLAGS} ${GSKIT_CREDENTIALS}
+    bash get_source.sh -openssl-branch=openssl-3.5 ${OPENJCEPLUS_FLAGS} ${GSKIT_FLAGS} ${GSKIT_CREDENTIALS}
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}"
   fi
 }


### PR DESCRIPTION
This includes CVE-2026-2673.

Temporary until 3.5.6 is released.

Related to https://github.com/eclipse-openj9/openj9/pull/23549