### PR TITLE
Continue to set JDK_BOOT_VERSION=7 on AIX for jdk8

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -137,8 +137,9 @@ then
   echo "Detecting boot jdk for: ${JAVA_TO_BUILD}"
   echo "Found build version: ${JAVA_FEATURE_VERSION}"
   JDK_BOOT_VERSION=$(( JAVA_FEATURE_VERSION - 1 ))
-  if [ "${JAVA_FEATURE_VERSION}" == "8" ] && [ "${VARIANT}" == "openj9" ]; then
+  if [ "${JAVA_FEATURE_VERSION}" == "8" ] && [ "${VARIANT}" == "openj9" ] && [ "${TARGET_OS}" != "AIX" ]; then
     # Boot OpenJ9 jdk8 with jdk8 so we can download the boot jdk
+    # except on AIX since it finds IBM Java 8 in /usr/java8_64 where keytool doesn't work to convert certificates
     JDK_BOOT_VERSION="8"
   elif [ "${JAVA_FEATURE_VERSION}" == "11" ] && [ "${VARIANT}" == "openj9" ]; then
     # OpenJ9 only supports building jdk-11 with jdk-11


### PR DESCRIPTION
Set this way the builds find /opt/java8_64/ which is an OpenJDK build and works. Otherwise the builds find /usr/java8_64 which is IBM Java 8 and keytool isn't working to parse the Mozilla certificates.

`keytool error: java.lang.Exception: Input not an X.509 certificate`

Related to https://github.com/ibmruntimes/temurin-build/pull/216/