### PR TITLE
Test OPENJCEPLUS_BRANCH instead of ADDITIONAL_FILE_NAME_TAG

### DIFF
--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -29,7 +29,6 @@
 # (because of GPL3), we therefore have to name the indexes of the CONFIG_PARAMS
 # map. This is why we can't have nice things.
 CONFIG_PARAMS=(
-ADDITIONAL_FILE_NAME_TAG
 ADOPTIUM_DEVKIT_LOCATION
 ADOPT_PATCHES
 ALSA
@@ -644,8 +643,6 @@ function configDefaults() {
   # By default do not bundle OpenJCEPlus
   BUILD_CONFIG[BUNDLE_OPENJCEPLUS]=${BUILD_CONFIG[BUNDLE_OPENJCEPLUS]:-false}
   BUILD_CONFIG[OPENJCEPLUS_BRANCH]="main"
-
-  BUILD_CONFIG[ADDITIONAL_FILE_NAME_TAG]=${BUILD_CONFIG[ADDITIONAL_FILE_NAME_TAG]:-""}
 }
 
 # Declare the map of build configuration that we're going to use

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -378,7 +378,7 @@ updateOpenj9Sources() {
 
     if [ "${BUILD_CONFIG[BUNDLE_OPENJCEPLUS]}" == "true" ]; then
       # Set the flags to get the OpenJCEPlus source code
-      if [ "${BUILD_CONFIG[ADDITIONAL_FILE_NAME_TAG]}" == "IBM" ]; then
+      if [[ "${BUILD_CONFIG[OPENJCEPLUS_BRANCH]}" == ibm-* ]]; then
         OPENJCEPLUS_FLAGS="-openjceplus-repo=https://github.ibm.com/runtimes/OpenJCEPlus.git -openjceplus-branch=${BUILD_CONFIG[OPENJCEPLUS_BRANCH]}"
       else
         OPENJCEPLUS_FLAGS="-openjceplus-repo=https://github.com/ibmruntimes/OpenJCEPlus.git -openjceplus-branch=${BUILD_CONFIG[OPENJCEPLUS_BRANCH]}"


### PR DESCRIPTION
When OPENJCEPLUS_BRANCH starts with "ibm-" use the internal repo.

Revert the unneeded https://github.com/ibmruntimes/temurin-build/pull/220